### PR TITLE
Update path to images on depot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ build_singularity_image() {
     local index=${2}
     local total=${3}
     local source=${4:-'docker://quay.io/biocontainers'}
-    local destination=${5:-'singularity@depot.galaxyproject.org:/srv/nginx/depot.galaxyproject.org/root/singularity/'}
+    local destination=${5:-'singularity@depot.galaxyproject.org:/srv/nginx/depot.galaxyproject.org/singularity/'}
 
     singularity build "${image}" "${source}/${image}" > /dev/null 2>&1
     rsync -azq -e 'ssh -i ssh_key -o StrictHostKeyChecking=no' "./${image}" "${destination}"


### PR DESCRIPTION
I had to do quite a bit of shuffling around to fix speed problems with the existing depot, the "new" depot server (rochefort) is a Debian VM that mounts depot and singularity paths via NFS. It was ok that they were dependent mounts when depot was local, but now that they're both NFS this prevents mount order failures.

ssh keys for depot/rochefort have changed but it doesn't look like those are persisted here. I seem to recall that they used to be somewhere, but I'm not finding it.